### PR TITLE
QS & SEE minor optimizations

### DIFF
--- a/src/engine/move_ordering.rs
+++ b/src/engine/move_ordering.rs
@@ -413,10 +413,8 @@ pub fn order_moves(
             let base_mvv_lva = mvv_lva_score(board, mv);
             let capture_hist = get_capture_history_score(mv, board);
             
-            if see_capture(board, mv, 300) {
+            if see_capture(board, mv, -50) {
                 9500000 + base_mvv_lva + capture_hist
-            } else if see_capture(board, mv, -50) {
-                7500000 + base_mvv_lva + capture_hist
             } else {
                 // Bad capture - use capture history to differentiate
                 500000 + capture_hist

--- a/src/engine/search.rs
+++ b/src/engine/search.rs
@@ -86,6 +86,11 @@ fn quiesce(
 
     for mv in movegen {
         if board.piece_on(mv.get_dest()).is_some() || mv.get_promotion().is_some() {
+            // SEE Pruning - filter out obviously bad captures
+            if !see_capture(board, mv, -50) {
+                continue;
+            }
+
             let mvv_lva = mvv_lva_score(board, mv);
             captures[count] = ScoredMove::new(mv, mvv_lva);
             count += 1;
@@ -117,11 +122,6 @@ fn quiesce(
             continue;
         }
         
-        // SEE pruning - skip obviously bad captures
-        if !see_capture(board, mv, -50) {
-            continue;
-        }
-
         let new_board = board.make_move_new(mv);
         let score = -quiesce(
             &new_board,


### PR DESCRIPTION
Refactors SEE pruning in QS search.
Lowers the use of SEE in move ordering by 50%